### PR TITLE
[Mailer] Support Amazon SES ListManagementOptions

### DIFF
--- a/Transport/SesApiAsyncAwsTransport.php
+++ b/Transport/SesApiAsyncAwsTransport.php
@@ -98,6 +98,11 @@ class SesApiAsyncAwsTransport extends SesHttpAsyncAwsTransport
         if ($header = $email->getHeaders()->get('X-SES-SOURCE-ARN')) {
             $request['FromEmailAddressIdentityArn'] = $header->getBodyAsString();
         }
+        if ($header = $email->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
+            if(preg_match("/^(contactListName=)*(?<ContactListName>[^;]+);\s?topicName=(?<TopicName>.+)$/ix", $header->getBodyAsString(), $listManagementOptions)) {
+                $request['ListManagementOptions'] = array_filter($listManagementOptions, fn($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
+            }
+        }
         if ($email->getReturnPath()) {
             $request['FeedbackForwardingEmailAddress'] = $email->getReturnPath()->toString();
         }

--- a/Transport/SesHttpAsyncAwsTransport.php
+++ b/Transport/SesHttpAsyncAwsTransport.php
@@ -88,6 +88,12 @@ class SesHttpAsyncAwsTransport extends AbstractTransport
             && $sourceArnHeader = $message->getOriginalMessage()->getHeaders()->get('X-SES-SOURCE-ARN')) {
             $request['FromEmailAddressIdentityArn'] = $sourceArnHeader->getBodyAsString();
         }
+        if (($message->getOriginalMessage() instanceof Message)
+            && $header = $message->getOriginalMessage()->getHeaders()->get('X-SES-LIST-MANAGEMENT-OPTIONS')) {
+            if(preg_match("/^(contactListName=)*(?<ContactListName>[^;]+);\s?topicName=(?<TopicName>.+)$/ix", $header->getBodyAsString(), $listManagementOptions)) {
+                $request['ListManagementOptions'] = array_filter($listManagementOptions, fn($e) => in_array($e, ['ContactListName', 'TopicName']), ARRAY_FILTER_USE_KEY);
+            }
+        }
         if ($message->getOriginalMessage() instanceof Message) {
             foreach ($message->getOriginalMessage()->getHeaders()->all() as $header) {
                 if ($header instanceof MetadataHeader) {


### PR DESCRIPTION
Amazon SES offers list management capabilities, which means customers can manage their own mailing lists, known as contact lists.
Amazon SES automatically enables the unsubscribe links/headers in every outgoing email when you specify the contactListName and topicName within ListManagementOptions in the SendEmail operation request.

Setting the `X-SES-LIST-MANAGEMENT-OPTIONS` header should accomplish this for all SES Transports now.

Ref: https://docs.aws.amazon.com/ses/latest/dg/sending-email-list-management.html